### PR TITLE
OfflineSpigotWhitelistResolver code improvement

### DIFF
--- a/src/main/java/dev/watchwolf/server/OfflineSpigotWhitelistResolver.java
+++ b/src/main/java/dev/watchwolf/server/OfflineSpigotWhitelistResolver.java
@@ -1,12 +1,12 @@
 package dev.watchwolf.server;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Spigot handles the whitelist by checking the user UUID to the authentication Mojang servers.
@@ -15,10 +15,11 @@ import java.util.ArrayList;
  * This class will disable the Spigot whitelist and will check itself the "whitelisted" users.
  */
 public class OfflineSpigotWhitelistResolver implements ServerWhitelistResolver, Listener {
-    public ArrayList<String> whitelistedUsers;
+
+    private final Set<String> whitelistedUsers;
 
     public OfflineSpigotWhitelistResolver(JavaPlugin plugin) {
-        this.whitelistedUsers = new ArrayList<>();
+        this.whitelistedUsers = ConcurrentHashMap.newKeySet();
 
         org.bukkit.Server server = plugin.getServer();
         server.setWhitelist(false); // the whitelist will be handled internally
@@ -26,13 +27,15 @@ public class OfflineSpigotWhitelistResolver implements ServerWhitelistResolver, 
     }
 
     @EventHandler
-    public void onJoin(PlayerJoinEvent e) {
-        Player p = e.getPlayer();
-        if (!this.whitelistedUsers.contains(p.getName())) p.kickPlayer("You're not whitelisted!");
+    public void onJoin(AsyncPlayerPreLoginEvent event) {
+        if (!this.whitelistedUsers.contains(event.getName())) {
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_WHITELIST, "You're not whitelisted!");
+        }
     }
 
     @Override
     public void addToWhitelist(String name) {
         this.whitelistedUsers.add(name);
     }
+
 }


### PR DESCRIPTION
As discussed in Discord, I have made minor code changes to the class mentioned above.

- PlayerJoinEvent should not be used for such purposes. AsyncPlayerPreLoginEvent is the way to go.
- Non-constant fields should not be public, especially not lists
- Changed List to Set for performance benefit and for a better thread safe impl then copy of write. 

While it is out of the scope of my PR since it could involve a wider change, I suggest using UUIDs instead of player names, which is the accepted good practice in Spigot for various reasons. Think for example what happens if as part of a test a player changes his username in the middle